### PR TITLE
Fix WoT Contract Detection

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -190,7 +190,7 @@
         <article id="_about">
             <p id="version">Mobile Route Advisor </p>
             <p id="update-status" class="_yellow-color" style="display: none">A newer version is available!</p>
-            <p><a href="https://github.com/mkoch227/ets2-mobile-route-advisor" target="_blank">https://github.com/mkoch227/ets2-mobile-route-advisor</a></p>
+            <p><a href="https://github.com/mike-koch/ets2-mobile-route-advisor" target="_blank">https://github.com/mike-koch/ets2-mobile-route-advisor</a></p>
         </article>
     </div>
 

--- a/dashboard.js
+++ b/dashboard.js
@@ -573,7 +573,7 @@ var g_translations;
 var g_skinConfig;
 
 // The current version of ets2-mobile-route-advisor
-var g_currentVersion = '3.3.2';
+var g_currentVersion = '3.3.3';
 
 // The currently running game
 var g_runningGame;

--- a/dashboard.js
+++ b/dashboard.js
@@ -63,11 +63,13 @@ Funbit.Ets.Telemetry.Dashboard.prototype.filter = function (data) {
     data.navigation.estimatedTime = getTime(data.navigation.estimatedTime, 24);
     data.navigation.estimatedTime12h = getTime(estimatedTime24h, 12);
     data.navigation.timeToDestination = processTimeDifferenceArray(timeToDestinationArray);
-    data.job.remainingTimeArray = getDaysHoursMinutesAndSeconds(data.job.remainingTime);
-    data.job.remainingTime = processTimeDifferenceArray(data.job.remainingTimeArray);
 
     // ETS2-specific logic
     data.isWorldOfTrucksContract = isWorldOfTrucksContract(data);
+
+    data.job.remainingTimeArray = getDaysHoursMinutesAndSeconds(data.job.remainingTime);
+    data.job.remainingTime = processTimeDifferenceArray(data.job.remainingTimeArray);
+
     if (data.isEts2) {
         data.jobIncome = getEts2JobIncome(data.job.income);
     }


### PR DESCRIPTION
The skin was parsing the remaining time before checking to see if it was a WoT contract, causing it to not work every time. Instead, check if it is a WoT contract before parsing the remaining time.
